### PR TITLE
Add 'eblob.%u.remove.size' handystats metric

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -2643,6 +2643,8 @@ int eblob_remove(struct eblob_backend *b, struct eblob_key *key)
 		", size: %" PRIu64 ".\n",
 		eblob_dump_id(key->id), ctl.data_offset, ctl.size);
 
+	FORMATTED(HANDY_COUNTER_INCREMENT, ("eblob.%u.remove.size", b->cfg.stat_id), ctl.size);
+
 err_out_bctl_release:
 	eblob_bctl_release(ctl.bctl);
 err_out_exit:


### PR DESCRIPTION
The metric counts size of records removed by users, so it doesn't count records removed by overwrites.
