### PR TITLE
Fix bases' statistics in .stat file

### DIFF
--- a/library/stat.c
+++ b/library/stat.c
@@ -201,7 +201,7 @@ static void eblob_stat_base_print(FILE *fp, struct eblob_backend *b) {
 	assert(b != NULL);
 	list_for_each_entry(bctl, &b->bases, base_entry) {
 		fprintf(fp, "BASE: %s\n", bctl->name);
-		eblob_stat_print(fp, b->stat_summary);
+		eblob_stat_print(fp, b->stat);
 	}
 }
 


### PR DESCRIPTION
There was a bug which lead to printing summary statistics for all bases instead of bases' statistics