### PR TITLE
Inspection and ioprio

### DIFF
--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -420,9 +420,15 @@ struct eblob_config {
 	 */
 	char			*chunks_dir;
 
+	/* IO nice parameters for background threads.
+	 * for more details: http://man7.org/linux/man-pages/man2/ioprio_set.2.html
+	 */
+	int			bg_ioprio_class;  // one of IOPRIO_CLASS_*
+	int			bg_ioprio_data; // priority level within @bg_ioprio_class
+
 	/* for future use */
 	uint64_t		__pad_64[8];
-	int			__pad_int[5];
+	int			__pad_int[3];
 	char			__pad_char[8];
 	void			*__pad_voidp[7];
 };

--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -756,6 +756,25 @@ int eblob_stat_json_get(struct eblob_backend *b, char **json_stat, size_t *size)
 int eblob_sync(struct eblob_backend *b);
 int eblob_defrag(struct eblob_backend *b);
 int eblob_periodic(struct eblob_backend *b);
+int eblob_inspect(struct eblob_backend *b);
+
+enum eblob_inspect_state {
+	EBLOB_INSPECT_STATE_NOT_STARTED,	/* no inspection is in progress */
+	EBLOB_INSPECT_STATE_INSPECTING		/* inspection is in progress */
+};
+
+/**
+ * eblob_start_inspect() - start inspection in background thread
+ */
+int eblob_start_inspect(struct eblob_backend *b);
+/**
+ * eblob_stop_inspect() - stop inspection in background thread
+ */
+int eblob_stop_inspect(struct eblob_backend *b);
+/**
+ * eblob_inspect_status() - get current state of background inspection
+ */
+int eblob_inspect_status(struct eblob_backend *b);
 
 struct eblob_flag_info {
 	uint64_t flag;

--- a/library/blob.c
+++ b/library/blob.c
@@ -2979,6 +2979,162 @@ int eblob_periodic(struct eblob_backend *b)
 	return err;
 }
 
+int eblob_start_inspect(struct eblob_backend *b) {
+	if (b->cfg.blob_flags & EBLOB_DISABLE_THREADS)
+		return -EINVAL;
+
+	if (b->want_inspect == EBLOB_INSPECT_STATE_INSPECTING) {
+		eblob_log(b->cfg.log, EBLOB_LOG_INFO, "inspect: inspection is in progress.\n");
+		return -EALREADY;
+	}
+
+	b->want_inspect = EBLOB_INSPECT_STATE_INSPECTING;
+	return 0;
+}
+
+int eblob_stop_inspect(struct eblob_backend *b) {
+	if (b->cfg.blob_flags & EBLOB_DISABLE_THREADS)
+		return -EINVAL;
+
+	if (b->want_inspect == EBLOB_INSPECT_STATE_NOT_STARTED) {
+		eblob_log(b->cfg.log, EBLOB_LOG_INFO, "inspect: inspection is not started.\n");
+		return -EALREADY;
+	}
+
+	b->want_inspect = EBLOB_INSPECT_STATE_NOT_STARTED;
+	return 0;
+}
+
+int eblob_inspect_status(struct eblob_backend *b) {
+	if (b->cfg.blob_flags & EBLOB_DISABLE_THREADS)
+		return -EINVAL;
+
+	return b->want_inspect;
+}
+
+/**
+ * eblob_inspect_thread() - executes eblob_inspect() if b->want_inspect was set.
+ */
+static void *eblob_inspect_thread(void *data) {
+	struct eblob_backend *b = data;
+	while(eblob_event_wait(&b->exit_event, 1) == -ETIMEDOUT) {
+		if (b->want_inspect) {
+			eblob_inspect(b);
+			b->want_inspect = 0;
+		}
+	}
+	return NULL;
+}
+
+/**
+ * eblob_inspect_record() - inspects one record addressed by @dc
+ */
+static int eblob_inspect_record(struct eblob_base_ctl *bctl, struct eblob_disk_control *dc, uint64_t index_offset) {
+	int err;
+	struct eblob_write_control wc;
+
+	memset(&wc, 0, sizeof(wc));
+	eblob_dc_to_wc(dc, &wc);
+	wc.bctl = bctl;
+	wc.index = bctl->index;
+	wc.data_fd = bctl->data_ctl.fd;
+	wc.ctl_data_offset = dc->position;
+	wc.index_fd = bctl->index_ctl.fd;
+	wc.ctl_index_offset = index_offset;
+
+	eblob_log(bctl->back->cfg.log, EBLOB_LOG_NOTICE, "inspect: i%d: inspecting record: %s\n", bctl->index,
+	          eblob_dump_id(dc->key.id));
+
+	// TODO: there should be more cases, so we can find, fix and/or mark headers' mismatch or invalidity
+	err = eblob_verify_checksum(bctl->back, &dc->key, &wc);
+	if (err == -EILSEQ)
+		err = 0; // ignore -EILSEQ error since corruption was already marked by eblob_verify_checksum()
+	return err;
+}
+
+/**
+ * eblob_inspect_bctl() - inspects one base addressed by @bctl
+ */
+static int eblob_inspect_bctl(struct eblob_base_ctl *bctl) {
+	int err = 0;
+	size_t index_size;
+	size_t read_offset, block_offset;
+	struct eblob_disk_control dc_block[100];
+	size_t read_size = sizeof(dc_block);
+	int read_err;
+	struct eblob_disk_control *dc, *dc_block_end;
+
+	eblob_bctl_hold(bctl);
+	if (eblob_binlog_enabled(&bctl->binlog)) {
+		eblob_log(bctl->back->cfg.log, EBLOB_LOG_INFO, "inspect: i%d: binlog enabled, skip the base\n",
+		          bctl->index);
+		eblob_bctl_release(bctl);
+		return 0;
+	}
+	// fix index_size to prevent validating incomplete recently added records
+	index_size = bctl->index_ctl.size;
+	pthread_mutex_unlock(&bctl->back->lock);
+
+	/* TODO: we should prevent overwriting/removing a key that can lead to checksum verification and other failures.
+	 * We can use binlog for it, but it requires applying binlog afterwards.
+	 */
+	eblob_log(bctl->back->cfg.log, EBLOB_LOG_INFO, "inspect: i%d: start the blob inspection\n", bctl->index);
+
+	for(read_offset = 0; read_offset < index_size && bctl->back->want_inspect; read_offset += read_size) {
+		read_size = EBLOB_MIN(read_size, index_size - read_offset);
+		read_err = __eblob_read_ll(bctl->index_ctl.fd, dc_block, read_size, read_offset);
+		if (read_err) {
+			eblob_log(bctl->back->cfg.log, EBLOB_LOG_ERROR, "inspect: i%d: failed to read index: fd: %d, "
+			                                                "read-offset: %zu, read-size: %zu, size: %"
+			                                                PRIu64 ": %s [%d]\n",
+			          bctl->index, bctl->index_ctl.fd, read_offset, read_size, index_size,
+			          strerror(-read_err), read_err);
+			err = read_err;
+			break;
+		}
+
+		dc_block_end  = dc_block + (read_size / sizeof(struct eblob_disk_control));
+		for (dc = dc_block; dc < dc_block_end && bctl->back->want_inspect; ++dc) {
+			eblob_convert_disk_control(dc);
+			// skip removed, uncommitted and records without checksum
+			if (dc->flags & (BLOB_DISK_CTL_REMOVE|BLOB_DISK_CTL_UNCOMMITTED|BLOB_DISK_CTL_NOCSUM))
+				continue;
+			block_offset = (void*)dc - (void*)dc_block;
+			err = eblob_inspect_record(bctl, dc, read_offset + block_offset);
+		}
+	}
+	pthread_mutex_lock(&bctl->back->lock);
+	eblob_bctl_release(bctl);
+	eblob_log(bctl->back->cfg.log, EBLOB_LOG_INFO, "inspect: i%d: finish the blob inspection\n", bctl->index);
+
+	return err;
+}
+
+/**
+ * eblob_inspect() - perform checksum verification for all data
+ */
+int eblob_inspect(struct eblob_backend *b) {
+	int err = 0;
+	struct eblob_base_ctl *it, *tmp;
+
+	pthread_mutex_lock(&b->inspect_lock);
+	eblob_log(b->cfg.log, EBLOB_LOG_INFO, "inspect: started\n");
+
+	pthread_mutex_lock(&b->lock);
+	list_for_each_entry_safe_reverse(it, tmp, &b->bases, base_entry) {
+		if (!b->want_inspect)
+			break;
+
+		// eblob_inspect_bctl will release @b->lock at the start and lock it at the end
+		err = eblob_inspect_bctl(it);
+	}
+	pthread_mutex_unlock(&b->lock);
+
+	eblob_log(b->cfg.log, EBLOB_LOG_INFO, "inspect: finished\n");
+	pthread_mutex_unlock(&b->inspect_lock);
+	return err;
+}
+
 void eblob_cleanup(struct eblob_backend *b)
 {
 	eblob_event_set(&b->exit_event);
@@ -2987,6 +3143,7 @@ void eblob_cleanup(struct eblob_backend *b)
 		pthread_join(b->sync_tid, NULL);
 		pthread_join(b->defrag_tid, NULL);
 		pthread_join(b->periodic_tid, NULL);
+		pthread_join(b->inspect_tid, NULL);
 	}
 
 	eblob_json_stat_destroy(b);
@@ -3174,9 +3331,13 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 	if (err != 0)
 		goto err_out_sync_lock_destroy;
 
-	err = eblob_json_stat_init(b);
+	err = eblob_mutex_init(&b->inspect_lock);
 	if (err != 0)
 		goto err_out_periodic_lock_destroy;
+
+	err = eblob_json_stat_init(b);
+	if (err != 0)
+		goto err_out_inspect_lock_destroy;
 
 	if (!(b->cfg.blob_flags & EBLOB_DISABLE_THREADS)) {
 		err = pthread_create(&b->sync_tid, NULL, eblob_sync_thread, b);
@@ -3197,10 +3358,19 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 			goto err_out_join_defrag;
 		}
 
+		err = pthread_create(&b->inspect_tid, NULL, eblob_inspect_thread, b);
+		if (err) {
+			eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "blob: eblob inspect thread creation failed: %d", err);
+			goto err_out_join_periodic;
+		}
+
 	}
 
 	return b;
 
+err_out_join_periodic:
+	eblob_event_set(&b->exit_event);
+	pthread_join(b->periodic_tid, NULL);
 err_out_join_defrag:
 	eblob_event_set(&b->exit_event);
 	pthread_join(b->defrag_tid, NULL);
@@ -3209,6 +3379,8 @@ err_out_join_sync:
 	pthread_join(b->sync_tid, NULL);
 err_out_json_stat_destroy:
 	eblob_json_stat_destroy(b);
+err_out_inspect_lock_destroy:
+	pthread_mutex_destroy(&b->inspect_lock);
 err_out_periodic_lock_destroy:
 	pthread_mutex_destroy(&b->periodic_lock);
 err_out_sync_lock_destroy:
@@ -3318,25 +3490,27 @@ static void eblob_mark_entry_corrupted(struct eblob_backend *b, struct eblob_key
 	assert(key != NULL);
 	assert(wc != NULL);
 
-	struct eblob_base_ctl *bctl = NULL, *it = NULL;
+	struct eblob_base_ctl *bctl = wc->bctl, *it = NULL;
 
 	// check that record is not marked corrupted yet
 	if (wc->flags & BLOB_DISK_CTL_CORRUPTED)
 		return;
 
-	// TODO(shaitan): bad idea to use global lock
-	pthread_mutex_lock(&b->lock);
-	// Tries to find bctl by its index from @wc
-	list_for_each_entry(it, &b->bases, base_entry) {
-		if (it->index == wc->index) {
-			bctl = it;
-			break;
+	// if @wc->bctl wasn't set, find it by index
+	if (!bctl) {
+		pthread_mutex_lock(&b->lock);
+		// Tries to find bctl by its index from @wc
+		list_for_each_entry(it, &b->bases, base_entry) {
+			if (it->index == wc->index) {
+				bctl = it;
+				break;
+			}
 		}
+		// if bctl is found, hold it to protect from defrag
+		if (bctl)
+			eblob_bctl_hold(bctl);
+		pthread_mutex_unlock(&b->lock);
 	}
-	// if bctl is found, hold it to protect from defrag
-	if (bctl)
-		eblob_bctl_hold(bctl);
-	pthread_mutex_unlock(&b->lock);
 
 	// offsets from wc are out-dated and can not be used if bctl is not found or it was defraged
 	if (!bctl || bctl->index_ctl.fd != wc->index_fd || bctl->data_ctl.fd != wc->data_fd)
@@ -3346,11 +3520,19 @@ static void eblob_mark_entry_corrupted(struct eblob_backend *b, struct eblob_key
 	if (eblob_binlog_enabled(&bctl->binlog))
 		goto err_out_release_bctl;
 
-	if (eblob_mark_header_corrupted(b, key, wc->index_fd, wc->ctl_index_offset))
+	if (eblob_mark_header_corrupted(b, key, wc->index_fd, wc->ctl_index_offset)) {
+		eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "blob: i%d: failed to mark corrupted record in index: offset:  %"
+		                                       PRIu64 "\n",
+		          wc->index, wc->ctl_index_offset);
 		goto err_out_release_bctl;
+	}
 
-	if (eblob_mark_header_corrupted(b, key, wc->data_fd, wc->ctl_data_offset))
+	if (eblob_mark_header_corrupted(b, key, wc->data_fd, wc->ctl_data_offset)) {
+		eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "blob: i%d: failed to mark corrupted in data: offset:  %"
+		                                       PRIu64 "\n",
+		          wc->index, wc->ctl_data_offset);
 		goto err_out_release_bctl;
+	}
 
 	eblob_stat_inc(bctl->stat, EBLOB_LST_RECORDS_CORRUPTED);
 	eblob_stat_add(bctl->stat, EBLOB_LST_CORRUPTED_SIZE, wc->total_size);
@@ -3363,14 +3545,15 @@ static void eblob_mark_entry_corrupted(struct eblob_backend *b, struct eblob_key
 	}
 
 err_out_release_bctl:
-	eblob_bctl_release(bctl);
+	if (!wc->bctl)
+		eblob_bctl_release(bctl);
 err_out:
 	return;
 }
 
 int eblob_verify_checksum(struct eblob_backend *b, struct eblob_key *key, struct eblob_write_control *wc) {
 	if (b->cfg.blob_flags & EBLOB_NO_FOOTER ||
-	    wc->flags & BLOB_DISK_CTL_NOCSUM)
+	    wc->flags & (BLOB_DISK_CTL_NOCSUM | BLOB_DISK_CTL_REMOVE | BLOB_DISK_CTL_UNCOMMITTED))
 		return 0;
 
 	if (wc->total_size <= wc->total_data_size + sizeof(struct eblob_disk_control)) {

--- a/library/blob.h
+++ b/library/blob.h
@@ -592,6 +592,8 @@ static inline const char *eblob_want_defrag_string(int want_defrag)
 
 char *eblob_dump_dc(const struct eblob_disk_control *dc, char *buffer, size_t size);
 
+int eblob_set_name(const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/blob.h
+++ b/library/blob.h
@@ -426,10 +426,12 @@ struct eblob_backend {
 	pthread_mutex_t		defrag_lock;
 	pthread_mutex_t		sync_lock;
 	pthread_mutex_t		periodic_lock;
+	pthread_mutex_t		inspect_lock;
 
 	pthread_t		defrag_tid;
 	pthread_t		sync_tid;
 	pthread_t		periodic_tid;
+	pthread_t		inspect_tid;
 
 	/*
 	 * Last time when data.stat file was updated. Data statistics is being updated by periodic thread
@@ -468,6 +470,12 @@ struct eblob_backend {
 	 * it is used for determining that blob has been defraged
 	 */
 	size_t		defrag_generation;
+
+	/* Set when inspection are requested
+	 * 0: inspection isn't requested or inspection stop is requested if it is in progress
+	 * otherwise: inspection is requested and is in progress
+	 */
+	int			want_inspect;
 };
 
 int eblob_add_new_base(struct eblob_backend *b);

--- a/library/blob.h
+++ b/library/blob.h
@@ -593,6 +593,7 @@ static inline const char *eblob_want_defrag_string(int want_defrag)
 char *eblob_dump_dc(const struct eblob_disk_control *dc, char *buffer, size_t size);
 
 int eblob_set_name(const char *format, ...);
+char *ioprio_class_string(int ioprio_class);
 
 #ifdef __cplusplus
 }

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -44,6 +44,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "ioprio.h"
+
 /**
  * eblob_want_defrag() - gets number of removed records/non-removed records
  * and compares it with total.
@@ -353,6 +355,13 @@ void *eblob_defrag_thread(void *data)
 		return NULL;
 
 	eblob_set_name("defrag_%u", b->cfg.stat_id);
+
+	if (b->cfg.bg_ioprio_class != IOPRIO_CLASS_NONE) {
+		if (eblob_ioprio_set(IOPRIO_PRIO_VALUE(b->cfg.bg_ioprio_class, b->cfg.bg_ioprio_data)) == -1) {
+			eblob_log(b->cfg.log, EBLOB_LOG_ERROR, "%s: failed to set ioprio: %s[%d]",
+			          __func__, strerror(errno), errno);
+		}
+	}
 
 	sleep_time = datasort_next_defrag(b);
 	while (1) {

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -352,6 +352,8 @@ void *eblob_defrag_thread(void *data)
 	if (b == NULL)
 		return NULL;
 
+	eblob_set_name("defrag_%u", b->cfg.stat_id);
+
 	sleep_time = datasort_next_defrag(b);
 	while (1) {
 		if ((sleep_time-- != 0) && (b->want_defrag == EBLOB_DEFRAG_STATE_NOT_STARTED)) {

--- a/library/index.c
+++ b/library/index.c
@@ -229,10 +229,9 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 	struct eblob_index_block *block = NULL;
 	struct eblob_disk_control dc, prev;
 	uint64_t block_count, block_id = 0, err_count = 0, offset = 0, prev_offset = 0;
-	int64_t removed = 0;
-	int64_t removed_size = 0;
-	int64_t uncommitted = 0;
-	int64_t uncommitted_size = 0;
+	int64_t removed = 0, removed_size = 0;
+	int64_t uncommitted = 0, uncommitted_size = 0;
+	int64_t corrupted = 0, corrupted_size = 0;
 	unsigned int i;
 	int err = 0;
 	int prev_filled = 0;
@@ -350,6 +349,10 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 					uncommitted++;
 					uncommitted_size += dc.disk_size + sizeof(struct eblob_disk_control);
 				}
+				if (dc.flags & eblob_bswap64(BLOB_DISK_CTL_CORRUPTED)) {
+					++corrupted;
+					corrupted_size += dc.disk_size + sizeof(struct eblob_disk_control);
+				}
 				eblob_bloom_set(bctl, &dc.key);
 			}
 
@@ -363,6 +366,8 @@ int eblob_index_blocks_fill(struct eblob_base_ctl *bctl)
 	eblob_stat_set(bctl->stat, EBLOB_LST_REMOVED_SIZE, removed_size);
 	eblob_stat_set(bctl->stat, EBLOB_LST_RECORDS_UNCOMMITTED, uncommitted);
 	eblob_stat_set(bctl->stat, EBLOB_LST_UNCOMMITTED_SIZE, uncommitted_size);
+	eblob_stat_set(bctl->stat, EBLOB_LST_RECORDS_CORRUPTED, corrupted);
+	eblob_stat_set(bctl->stat, EBLOB_LST_CORRUPTED_SIZE, corrupted_size);
 	return 0;
 
 err_out_drop_tree:

--- a/library/ioprio.h
+++ b/library/ioprio.h
@@ -1,0 +1,78 @@
+/*
+ * 2017+ Copyright (c) Kirill Smorodinnikov <shaitkir@gmail.com>
+ * All rights reserved.
+ *
+ * This file is part of Eblob.
+ *
+ * Eblob is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Eblob is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Eblob.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __EBLOB_IOPRIO_H
+#define __EBLOB_IOPRIO_H
+
+#include <sys/syscall.h>
+
+/**
+ * IOPRIO_* were copied from linux/include/linux/ioprio.h:
+ * https://github.com/torvalds/linux/blob/0b07194bb55ed836c2cc7c22e866b87a14681984/include/linux/ioprio.h
+ */
+
+/*
+ * Gives us 8 prio classes with 13-bits of data for each class
+ */
+#define IOPRIO_CLASS_SHIFT	(13)
+#define IOPRIO_PRIO_MASK	((1UL << IOPRIO_CLASS_SHIFT) - 1)
+
+#define IOPRIO_PRIO_CLASS(mask)	((mask) >> IOPRIO_CLASS_SHIFT)
+#define IOPRIO_PRIO_DATA(mask)	((mask) & IOPRIO_PRIO_MASK)
+#define IOPRIO_PRIO_VALUE(class, data)	(((class) << IOPRIO_CLASS_SHIFT) | data)
+
+#define ioprio_valid(mask)	(IOPRIO_PRIO_CLASS((mask)) != IOPRIO_CLASS_NONE)
+
+/*
+ * These are the io priority groups as implemented by CFQ. RT is the realtime
+ * class, it always gets premium service. BE is the best-effort scheduling
+ * class, the default for any process. IDLE is the idle scheduling class, it
+ * is only served when no one else is using the disk.
+ */
+enum {
+	IOPRIO_CLASS_NONE,
+	IOPRIO_CLASS_RT,
+	IOPRIO_CLASS_BE,
+	IOPRIO_CLASS_IDLE,
+};
+
+
+enum {
+	IOPRIO_WHO_PROCESS = 1,
+	IOPRIO_WHO_PGRP,
+	IOPRIO_WHO_USER,
+};
+
+static inline int ioprio_set(int which, int who, int ioprio) {
+	return syscall(SYS_ioprio_set, which, who, ioprio);
+}
+static inline int ioprio_get(int which, int who) {
+	return syscall(SYS_ioprio_get, which, who);
+}
+
+static inline int eblob_ioprio_set(int ioprio) {
+	return ioprio_set(IOPRIO_WHO_PROCESS, 0, ioprio);
+}
+
+static inline int eblob_ioprio_get() {
+	return ioprio_get(IOPRIO_WHO_PROCESS, 0);
+}
+
+#endif /* __EBLOB_IOPRIO_H */

--- a/library/json_stat.cpp
+++ b/library/json_stat.cpp
@@ -15,7 +15,7 @@ extern "C" {
 
 struct json_stat_cache {
 	json_stat_cache()
-	: timestamp({0, 0})
+	: timestamp{0, 0}
 	{}
 
 	std::string		json;

--- a/library/json_stat.cpp
+++ b/library/json_stat.cpp
@@ -77,6 +77,9 @@ static void eblob_stat_config_json(struct eblob_backend *b, rapidjson::Value &st
 	stat.AddMember("blob_size_limit", b->cfg.blob_size_limit, allocator);
 	stat.AddMember("defrag_time", b->cfg.defrag_time, allocator);
 	stat.AddMember("defrag_splay", b->cfg.defrag_splay, allocator);
+	stat.AddMember("bg_ioprio_class", b->cfg.bg_ioprio_class, allocator);
+	stat.AddMember("bg_ioprio_data", b->cfg.bg_ioprio_data, allocator);
+	stat.AddMember("string_bg_ioprio_class", ioprio_class_string(b->cfg.bg_ioprio_class), allocator);
 }
 
 static char *get_dir_path(const char *data_path) {

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -128,6 +128,8 @@ int _eblob_base_ctl_cleanup(struct eblob_base_ctl *ctl)
 	eblob_stat_set(ctl->stat, EBLOB_LST_REMOVED_SIZE, 0);
 	eblob_stat_set(ctl->stat, EBLOB_LST_RECORDS_UNCOMMITTED, 0);
 	eblob_stat_set(ctl->stat, EBLOB_LST_UNCOMMITTED_SIZE, 0);
+	eblob_stat_set(ctl->stat, EBLOB_LST_RECORDS_CORRUPTED, 0);
+	eblob_stat_set(ctl->stat, EBLOB_LST_CORRUPTED_SIZE, 0);
 
 	return 0;
 }


### PR DESCRIPTION
- inspection in background threads goes through records, verifies their checksum and marks corrupted
- allow to set ioprio to all internal threads: defrag, periodic etc.