### PR TITLE
defrag: call fdatasync during datasort

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+eblob (0.24.7) unstable; urgency=low
+
+  * defrag: call fdatasync during datasort
+
+ -- Kirill Smorodinnikov <shaitkir@gmail.com>  Mon, 25 Mar 2019 12:34:28 +0300
+
 eblob (0.24.6) unstable; urgency=low
 
   * sha512: remove duplicated code


### PR DESCRIPTION
It synchronously flushes dirty pages that were written with low priority io and thereby controls number of such dirty pages.