### PR TITLE
Allow to trigger defrag using specified directory for chunks

### DIFF
--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -697,6 +697,14 @@ int eblob_start_defrag(struct eblob_backend *b);
  */
 int eblob_start_defrag_level(struct eblob_backend *b, enum eblob_defrag_state level);
 
+/*!
+ * eblob_start_defrag_in_dir() - overload version of eblob_start_defrag with defrag-level and chunks_dir params.
+ * @b - eblob backend instance
+ * @level - level of defragmentation
+ * @chunks_dir - directory for temporary chunks (overrides value specified in config)
+ */
+int eblob_start_defrag_in_dir(struct eblob_backend *b, enum eblob_defrag_state level, const char *chunks_dir);
+
 /*
  * eblob_start_index_sort() - forces defragmentation thread to sort index regardless of timer
  */
@@ -770,6 +778,8 @@ int eblob_sync(struct eblob_backend *b);
 int eblob_defrag(struct eblob_backend *b);
 int eblob_periodic(struct eblob_backend *b);
 int eblob_inspect(struct eblob_backend *b);
+
+int eblob_defrag_in_dir(struct eblob_backend *b, char *chunks_dir);
 
 enum eblob_inspect_state {
 	EBLOB_INSPECT_STATE_NOT_STARTED,	/* no inspection is in progress */

--- a/library/blob.c
+++ b/library/blob.c
@@ -3177,6 +3177,14 @@ void eblob_cleanup(struct eblob_backend *b)
 
 	eblob_json_stat_destroy(b);
 
+	pthread_mutex_destroy(&b->defrag_state_lock);
+	pthread_mutex_destroy(&b->inspect_lock);
+	pthread_mutex_destroy(&b->periodic_lock);
+	pthread_mutex_destroy(&b->sync_lock);
+	pthread_mutex_destroy(&b->defrag_lock);
+
+	eblob_event_destroy(&b->exit_event);
+
 	eblob_bases_cleanup(b);
 
 	eblob_hash_destroy(&b->hash);
@@ -3189,6 +3197,8 @@ void eblob_cleanup(struct eblob_backend *b)
 
 	eblob_stat_destroy(b->stat);
 	eblob_stat_destroy(b->stat_summary);
+
+	pthread_mutex_destroy(&b->lock);
 
 	(void)lockf(b->lock_fd, F_ULOCK, 0);
 	(void)close(b->lock_fd);

--- a/library/blob.h
+++ b/library/blob.h
@@ -446,11 +446,20 @@ struct eblob_backend {
 	char			*base_dir;
 
 	/*
+	 * lock for changing want_defrag and defrag_chunks_dir
+	 */
+	pthread_mutex_t		defrag_state_lock;
+	/*
 	 * Set when defrag/data-sort are explicitly requested
 	 * 0:		data-sort should be preformed according to defrag_timeout
 	 * otherwise:	defragmentation explicitly requested via eblob_start_defrag() with appropriate defrag level set in parameter
 	 */
-	volatile int		want_defrag;
+	int			want_defrag;
+	/*
+	 * If set, overrides chunks_dir from config file for the next defragmentation
+	 */
+	char			*defrag_chunks_dir;
+
 	/* Cached vfs stats */
 	struct statvfs		vfs_stat;
 	/* File descriptor used for database locking */

--- a/library/datasort.h
+++ b/library/datasort.h
@@ -82,6 +82,20 @@ struct datasort_cfg {
 	uint64_t			chunk_size;
 	/* Limit on number of records in one chunk */
 	uint64_t			chunk_limit;
+	/* Pointer to backend */
+	struct eblob_backend		*b;
+	/* Logging */
+	struct eblob_log		*log;
+	/* Pointer to one or more base controls */
+	struct eblob_base_ctl		**bctl;
+	/* Number of pointers in **bctl */
+	int				bctl_cnt;
+	/* Directory for chunks. If not specified */
+	const char			*chunks_dir;
+};
+
+struct datasort_ctl {
+	struct datasort_cfg		*cfg;
 	/* Lock used by blob iterator */
 	pthread_mutex_t			lock;
 	/* Splitter chunks */
@@ -94,14 +108,6 @@ struct datasort_cfg {
 	char				*dir;
 	/* Chunks directory - if not defined, then chunks are stored in dir */
 	char				*chunks_dir;
-	/* Pointer to backend */
-	struct eblob_backend		*b;
-	/* Logging */
-	struct eblob_log		*log;
-	/* Pointer to one or more base controls */
-	struct eblob_base_ctl		**bctl;
-	/* Number of pointers in **bctl */
-	int				bctl_cnt;
 	/* Pointer to sorted bctl */
 	struct eblob_base_ctl		*sorted_bctl;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(eblob_defrag_test unit/defrag.cpp unit/eblob_wrapper.cpp)
 target_link_libraries(eblob_defrag_test eblob ${Boost_LIBRARIES})
 add_custom_target(test_defrag
                   COMMAND "${CMAKE_CURRENT_BINARY_DIR}/eblob_defrag_test"
-                  DEPENDS ${TEST_DEPS} eblob_defrag_test)
+                  DEPENDS ${TESTS_DEPS} eblob_defrag_test)
 
 set(TESTS_LIST
     eblob_stress

--- a/tests/unit/defrag.cpp
+++ b/tests/unit/defrag.cpp
@@ -5,22 +5,20 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 
-#include "eblob_wrapper.h"
+#include <iostream>
+#include <functional>
+#include <random>
+#include <utility>
+#include <vector>
 
+#include <err.h>
+#include <sysexits.h>
+
+#include "eblob/eblob.hpp"
+#include "eblob_wrapper.h"
 #include "library/blob.h"
 #include "library/datasort.h"
 #include "library/list.h"
-
-#include "eblob/eblob.hpp"
-
-#include <vector>
-#include <utility>
-#include <random>
-#include <iostream>
-#include <functional>
-
-#include <sysexits.h>
-#include <err.h>
 
 
 eblob_config_test_wrapper initialize_eblob_config_for_defrag() {

--- a/tests/unit/eblob_wrapper.cpp
+++ b/tests/unit/eblob_wrapper.cpp
@@ -50,6 +50,10 @@ void eblob_config_test_wrapper::reset_dirs() {
 	config.chunks_dir = const_cast<char*>(data_dir_.c_str());
 }
 
+std::string eblob_config_test_wrapper::base_dir() const {
+	return data_dir_;
+}
+
 item_t::item_t(uint64_t key_, const eblob_key &hashed_key_, const std::vector<char> &value_)
 : key(key_)
 , value(value_) {

--- a/tests/unit/eblob_wrapper.cpp
+++ b/tests/unit/eblob_wrapper.cpp
@@ -1,13 +1,11 @@
 #include "eblob_wrapper.h"
 
 #include <boost/filesystem.hpp>
-
-#include <library/blob.h>
-#include <library/crypto/sha512.h>
-
-#include <eblob/eblob.hpp>
-
 #include <vector>
+
+#include "eblob/eblob.hpp"
+#include "library/blob.h"
+#include "library/crypto/sha512.h"
 
 
 eblob_config_test_wrapper::eblob_config_test_wrapper(bool cleanup_files)

--- a/tests/unit/eblob_wrapper.h
+++ b/tests/unit/eblob_wrapper.h
@@ -24,6 +24,9 @@ public:
 
 	void reset_dirs();
 
+	// base directory where backend should store everything
+	std::string base_dir() const;
+
 private:
 	void cleanup_files();
 

--- a/tests/unit/eblob_wrapper.h
+++ b/tests/unit/eblob_wrapper.h
@@ -2,14 +2,13 @@
 
 #include <boost/filesystem.hpp>
 
-#include <eblob/eblob.hpp>
-
-#include <library/blob.h>
-#include <library/crypto/sha512.h>
-
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "eblob/eblob.hpp"
+#include "library/blob.h"
+#include "library/crypto/sha512.h"
 
 class eblob_config_test_wrapper {
 public:


### PR DESCRIPTION
It will affect only triggered defrag, so other defrags will use either specified directory for them or specified in config or working directory for blob.

TODO:
- [x] tests