### PR TITLE
remove force argument in eblob_base_setup_base

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -1075,7 +1075,7 @@ int eblob_blob_iterate(struct eblob_iterate_control *ctl)
 
 	/* Wait until nobody uses bctl->data */
 	eblob_base_wait_locked(ctl->base);
-	err = eblob_base_setup_data(ctl->base, 0);
+	err = eblob_base_setup_data(ctl->base);
 	if (err) {
 		pthread_mutex_unlock(&ctl->base->lock);
 		ctl->err = err;

--- a/library/blob.h
+++ b/library/blob.h
@@ -387,7 +387,7 @@ inline static void eblob_iovec_get_bounds(struct eblob_iovec_bounds *bounds,
 void eblob_base_ctl_cleanup(struct eblob_base_ctl *ctl);
 int _eblob_base_ctl_cleanup(struct eblob_base_ctl *ctl);
 
-int eblob_base_setup_data(struct eblob_base_ctl *ctl, int force);
+int eblob_base_setup_data(struct eblob_base_ctl *ctl);
 
 int eblob_want_defrag(struct eblob_base_ctl *bctl);
 

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -1218,7 +1218,7 @@ static int datasort_swap_memory(struct datasort_ctl *ds_ctl)
 	sorted_bctl->index_ctl = index;
 
 	/* Setup new base */
-	if ((err = eblob_base_setup_data(sorted_bctl, 1)) != 0) {
+	if ((err = eblob_base_setup_data(sorted_bctl)) != 0) {
 		EBLOB_WARNC(dcfg->log, EBLOB_LOG_ERROR, -err, "defrag: eblob_base_setup_data: FAILED");
 		goto err_free_base;
 	}

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -64,7 +64,7 @@ static const char *eblob_get_base(const char *blob_base)
 	return base;
 }
 
-int eblob_base_setup_data(struct eblob_base_ctl *ctl, int force)
+int eblob_base_setup_data(struct eblob_base_ctl *ctl)
 {
 	struct stat st;
 	int err;
@@ -95,9 +95,7 @@ int eblob_base_setup_data(struct eblob_base_ctl *ctl, int force)
 		goto err_out_exit;
 	}
 
-	if ((st.st_size && ((unsigned long long)st.st_size != ctl->data_ctl.size)) || force) {
-		ctl->data_ctl.size = st.st_size;
-	}
+	ctl->data_ctl.size = st.st_size;
 
 err_out_exit:
 	return err;
@@ -166,7 +164,7 @@ static int eblob_base_open_sorted(struct eblob_base_ctl *bctl, const char *dir_b
 		goto err_out_free;
 	}
 
-	err = eblob_base_setup_data(bctl, 0);
+	err = eblob_base_setup_data(bctl);
 	if (err)
 		goto err_out_close;
 
@@ -253,7 +251,7 @@ again:
 			goto err_out_close_data;
 		}
 
-		err = eblob_base_setup_data(ctl, 0);
+		err = eblob_base_setup_data(ctl);
 		if (err)
 			goto err_out_close_index;
 


### PR DESCRIPTION
force option was introduced in order to remmap data independently
of size at 951c9f686a0f5f3a2657de44cb4c26b93246d7a0 commit.
After that code with remapping was removed and option not in
4adb4ed1c65ee53d1854d7137d236ac7cadc7d23 commit