### PR TITLE
Feat: single pass defrag

### DIFF
--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -433,8 +433,19 @@ struct eblob_config {
 	int			bg_ioprio_class;  // one of IOPRIO_CLASS_*
 	int			bg_ioprio_data; // priority level within @bg_ioprio_class
 
+	/*
+	 * When we have pretty large files we don't want to make external merge sort.
+	 * Instead we just iterate over sorted indexes and write resulting blob in order
+	 * That threshold should be ~ disk_seek_time * avg_linear_disk_speed / 2
+	 * division by 2 is here because we can do 2 reads and 2 writes best (total 4 passes) via mergesort
+	 * and 1 read and 1 write via single pass sort. So if time consumed by seeks is less than 2 linear accesses
+	 * we improve our total speed.
+	 * For modern HDD this should be about 512 KiB
+	 */
+	uint64_t                single_pass_file_size_threshold;
+
 	/* for future use */
-	uint64_t		__pad_64[8];
+	uint64_t		__pad_64[7];
 	int			__pad_int[3];
 	char			__pad_char[8];
 	void			*__pad_voidp[7];
@@ -736,6 +747,9 @@ enum eblob_stat_global_flavour {
 	EBLOB_GST_INDEX_READS,
 	EBLOB_GST_DATASORT_COMPLETION_TIME,
 	EBLOB_GST_DATASORT_COMPLETION_STATUS,
+	EBLOB_GST_DATASORT_VIEW_USED_NUMBER,
+	EBLOB_GST_DATASORT_SORTED_VIEW_USED_NUMBER,
+	EBLOB_GST_DATASORT_SINGLE_PASS_VIEW_USED_NUMBER,
 	EBLOB_GST_MAX,
 };
 

--- a/library/datasort.h
+++ b/library/datasort.h
@@ -59,10 +59,12 @@ struct datasort_chunk {
 	struct eblob_disk_control	*index;
 	/* Number of reserved records including already used */
 	uint64_t			index_size;
-	/* Set to 1 if chunk came from sorted bctl */
-	uint8_t				already_sorted;
+	/* Set to 0 if chunk should not be sorted during sort phase
+	 * e.g. it came from sorted bctl or we are using single-pass sorting
+	 */
+	uint8_t				need_sort;
 	/* Set to 1 if chunk is just a view from base ctl
-	 * View can be created only from sorted base ctl. Instead it doesn't make a sense
+	 * View can be created from sorted base ctl or when we use single-pass sorting.
 	 * We need this field in destroying to distinguish cases when we own and don't own a file descriptor fd
 	 */
 	uint8_t 		 	base_view;

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -156,6 +156,9 @@ int eblob_defrag_in_dir(struct eblob_backend *b, char *chunks_dir)
 	pthread_mutex_lock(&b->defrag_lock);
 
 	eblob_stat_set(b->stat, EBLOB_GST_DATASORT_START_TIME, time(NULL));
+	eblob_stat_set(b->stat, EBLOB_GST_DATASORT_VIEW_USED_NUMBER, 0);
+	eblob_stat_set(b->stat, EBLOB_GST_DATASORT_SORTED_VIEW_USED_NUMBER, 0);
+	eblob_stat_set(b->stat, EBLOB_GST_DATASORT_SINGLE_PASS_VIEW_USED_NUMBER, 0);
 
 	/* Count approximate number of bases */
 	list_for_each_entry(bctl, &b->bases, base_entry)

--- a/library/json_stat.cpp
+++ b/library/json_stat.cpp
@@ -79,6 +79,11 @@ static void eblob_stat_config_json(struct eblob_backend *b, rapidjson::Value &st
 	stat.AddMember("blob_size_limit", b->cfg.blob_size_limit, allocator);
 	stat.AddMember("defrag_time", b->cfg.defrag_time, allocator);
 	stat.AddMember("defrag_splay", b->cfg.defrag_splay, allocator);
+	stat.AddMember("periodic_timeout", b->cfg.periodic_timeout, allocator);
+	stat.AddMember("stat_id", b->cfg.stat_id, allocator);
+	if (b->cfg.chunks_dir != nullptr) {
+		stat.AddMember("chunks_dir", rapidjson::StringRef(b->cfg.chunks_dir), allocator);
+	}
 	stat.AddMember("bg_ioprio_class", b->cfg.bg_ioprio_class, allocator);
 	stat.AddMember("bg_ioprio_data", b->cfg.bg_ioprio_data, allocator);
 	stat.AddMember("single_pass_file_size_threshold", b->cfg.single_pass_file_size_threshold, allocator);

--- a/library/json_stat.cpp
+++ b/library/json_stat.cpp
@@ -81,6 +81,7 @@ static void eblob_stat_config_json(struct eblob_backend *b, rapidjson::Value &st
 	stat.AddMember("defrag_splay", b->cfg.defrag_splay, allocator);
 	stat.AddMember("bg_ioprio_class", b->cfg.bg_ioprio_class, allocator);
 	stat.AddMember("bg_ioprio_data", b->cfg.bg_ioprio_data, allocator);
+	stat.AddMember("single_pass_file_size_threshold", b->cfg.single_pass_file_size_threshold, allocator);
 	auto ioprio_class = ioprio_class_string(b->cfg.bg_ioprio_class);
 	stat.AddMember("string_bg_ioprio_class", rapidjson::Value(ioprio_class, allocator), allocator);
 }

--- a/library/stat.h
+++ b/library/stat.h
@@ -110,6 +110,21 @@ static const struct eblob_stat_entry eblob_stat_default_global[] = {
 		{0}
 	},
 	{
+		"datasort_view_used_number",
+		EBLOB_GST_DATASORT_VIEW_USED_NUMBER,
+		{0}
+	},
+	{
+		"datasort_sorted_view_used_number",
+		EBLOB_GST_DATASORT_SORTED_VIEW_USED_NUMBER,
+		{0}
+	},
+	{
+		"datasort_single_pass_view_used_number",
+		EBLOB_GST_DATASORT_SINGLE_PASS_VIEW_USED_NUMBER,
+		{0}
+	},
+	{
 		"MAX",
 		EBLOB_GST_MAX,
 		{0}

--- a/tests/stress/stress.c
+++ b/tests/stress/stress.c
@@ -828,6 +828,7 @@ main(int argc, char **argv)
 	bcfg.log = &logger;
 	bcfg.records_in_blob = cfg.blob_records;
 	bcfg.sync = cfg.blob_sync;
+	bcfg.single_pass_file_size_threshold = 512 << 10;
 	cfg.b = eblob_init(&bcfg);
 	if (cfg.b == NULL)
 		errx(EX_OSERR, "eblob_init");

--- a/tests/unit/eblob_wrapper.h
+++ b/tests/unit/eblob_wrapper.h
@@ -92,8 +92,7 @@ public:
 	: wrapper_(wrapper)
 	, gen_(std::mt19937(seed))
 	, dist_(std::move(d))
-	, data_dist_('a', 'a' + 26)
-	{
+	, data_dist_('a', 'a' + 26) {
 	}
 
 	item_t generate_item(uint64_t key) {


### PR DESCRIPTION
Chained with #36 
This PR enables single-pass defragmentation for blobs with average size greater than defined.
In the case of single pass defrag we need:
`read_linear_speed/alive_blob_size + write_linear_speed/alive_blob_size + seek_time*number_of_alive_records ` time
compared to
`(read_linear_speed/alive_blob_size + write_linear_speed/alive_blob_size)*2` time 
in merge-sort implementation.
We can see, that in case when we have files greater than ~500 KiB single pass defrag will run faster than merge-sort defrag.

When using single-pass defrag we skip `split` phase(making a view as it is done when compacting already sorted blobs) and `sort` phase (we only sort index if required during `split` phase). After that we iterate through the whole sorted index writing resulting blob which will be already sorted.
