### PR TITLE
defrag a base after closing with corresponding flags

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -1769,7 +1769,7 @@ static int eblob_write_prepare_disk_ll(struct eblob_backend *b, struct eblob_key
 			goto err_out_exit;
 
 		if (!ctl->index_ctl.sorted)
-			datasort_force_sort(b);
+			datasort_plan_base_sort(b, ctl);
 
 		ctl = list_last_entry(&b->bases, struct eblob_base_ctl, base_entry);
 	}
@@ -3369,6 +3369,8 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 
 	INIT_LIST_HEAD(&b->bases);
 	b->max_index = -1;
+
+	INIT_LIST_HEAD(&b->closed_unsorted_bases);
 
 	err = eblob_l2hash_init(&b->l2hash);
 	if (err) {

--- a/library/datasort.h
+++ b/library/datasort.h
@@ -126,8 +126,9 @@ int datasort_cleanup_stale(struct eblob_log *log, char *base, char *dir);
 /* Is base sorted or not? */
 int datasort_base_is_sorted(struct eblob_base_ctl *bctl);
 
-/* Forces data-sort to process as soon as possible */
-int datasort_force_sort(struct eblob_backend *b);
+/* Enqueue a base to the next defragmentation */
+int datasort_plan_base_sort(struct eblob_backend *b, struct eblob_base_ctl *bctl);
+
 /* Returns number of seconds till next defrag */
 uint64_t datasort_next_defrag(const struct eblob_backend *b);
 

--- a/library/index.c
+++ b/library/index.c
@@ -854,6 +854,10 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	bctl->index_ctl.sorted = 1;
 	b->defrag_generation += 1;
 
+	if (b->cfg.blob_flags & EBLOB_AUTO_INDEXSORT) {
+		list_del_init(&bctl->closed_unsorted_base_entry);
+	}
+
 	/* Unlock */
 	pthread_rwlock_unlock(&b->hash.root_lock);
 	pthread_mutex_unlock(&bctl->lock);

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -362,6 +362,7 @@ struct eblob_base_ctl *eblob_base_ctl_new(struct eblob_backend *b, int index,
 	ctl->back = b;
 	ctl->index = index;
 	ctl->index_ctl.fd = -1;
+	INIT_LIST_HEAD(&ctl->closed_unsorted_base_entry);
 
 	memcpy(ctl->name, name, name_len);
 	ctl->name[name_len] = '\0';
@@ -503,6 +504,22 @@ void eblob_bases_cleanup(struct eblob_backend *b)
 		free(ctl);
 	}
 }
+
+
+/**
+ * eblob_extract_base_ctl() - extract a base from bases list and closed unsorted bases list in backend object
+ * NB! Caller should hold backend lock
+ */
+int eblob_extract_base_ctl(struct eblob_base_ctl *bctl) {
+	if (bctl == NULL) {
+		return -EINVAL;
+	}
+
+	__list_del(bctl->closed_unsorted_base_entry.prev, bctl->closed_unsorted_base_entry.next);
+	__list_del(bctl->base_entry.prev, bctl->base_entry.next);
+	return 0;
+}
+
 
 static int eblob_scan_base(struct eblob_backend *b)
 {


### PR DESCRIPTION
There are EBLOB_AUTO_INDEX_SORT, EBLOB_AUTO_DATA_SORT flags and we want
to closed bases will be defragmentated in the near time. So the solution
is to enqueue such bases in the queue of next defragmentation and choose
first bases from the queue.