### PR TITLE
add sorting by position in a blob file

### DIFF
--- a/include/eblob/blob.h
+++ b/include/eblob/blob.h
@@ -315,6 +315,11 @@ static inline void eblob_convert_disk_control(struct eblob_disk_control *ctl)
  */
 #define EBLOB_USE_VIEWS			(1<<12)
 
+/*
+ * Enable chunk splitting by position in a blob while defrag
+ */
+#define EBLOB_SORT_BY_POS			(1<<13)
+
 
 struct eblob_config {
 	/* blob flags above */
@@ -494,6 +499,7 @@ struct eblob_iterate_callbacks {
 #define EBLOB_ITERATE_FLAGS_READONLY		(1<<1)	/* do not modify entries while iterating a blob */
 #define EBLOB_ITERATE_FLAGS_INITIAL_LOAD	(1<<2)	/* set on initial load */
 #define EBLOB_ITERATE_FLAGS_VERIFY_CHECKSUM	(1<<3)	/* verify checksum for entries while iterating a blob */
+#define EBLOB_ITERATE_FLAGS_BY_POSITION	(1<<4)	/* iterate over entries in ascending order by position */
 
 /**
  * Structure which controls which keys should be iterated over.
@@ -871,7 +877,7 @@ static inline const char *eblob_dump_dctl_flags(uint64_t flags) {
 }
 
 static inline const char *eblob_dump_blob_flags(unsigned int flags) {
-	static __thread char buffer[256];
+	static __thread char buffer[512];
 	static struct eblob_flag_info infos[] = {
 		{ EBLOB_RESERVE_10_PERCENTS,		"reserve_10_percents"},
 		{ EBLOB_OVERWRITE_COMMITS,		"overwrite_commits"},
@@ -885,6 +891,7 @@ static inline const char *eblob_dump_blob_flags(unsigned int flags) {
 		{ EBLOB_DISABLE_THREADS,		"disabled_threads"},
 		{ EBLOB_AUTO_INDEXSORT,			"auto_indexsort"},
 		{ EBLOB_USE_VIEWS,			"use_views"},
+		{ EBLOB_SORT_BY_POS,			"sort_by_pos"},
 	};
 
 	eblob_dump_flags_raw(buffer, sizeof(buffer), flags, infos, sizeof(infos) / sizeof(infos[0]));

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -749,6 +749,9 @@ static int datasort_split(struct datasort_ctl *ds_ctl)
 		ictl.iterator_cb.iterator_init = datasort_split_iterator_init;
 		ictl.iterator_cb.iterator_free = datasort_split_iterator_free;
 
+		if (dcfg->b->cfg.blob_flags & EBLOB_SORT_BY_POS)
+			ictl.flags |= EBLOB_ITERATE_FLAGS_BY_POSITION;
+
 		EBLOB_WARNX(dcfg->log, EBLOB_LOG_INFO, "defrag: split: start, name: %s",
 				ictl.base->name);
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -27,6 +27,12 @@ $(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100
 $(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F6231
 $(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F6158
 
+# Big and small stress tests with sorting by position
+$(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F12375
+$(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F12302
+$(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F14423
+$(find . -name eblob_stress) -m0 -f100 -D0 -I30000 -o2000 -i100 -l4 -r 100 -S100 -F14350
+
 # Use specific datasort_dir for sorting chunks
 $(find . -name eblob_stress) -m0 -f1000 -D0 -I300000 -o20000 -i1000 -l4 -r 1000 -S10 -F2263 -P 1
 

--- a/tests/unit/eblob_wrapper.cpp
+++ b/tests/unit/eblob_wrapper.cpp
@@ -8,8 +8,9 @@
 #include "library/crypto/sha512.h"
 
 
-eblob_config_test_wrapper::eblob_config_test_wrapper(bool cleanup_files)
-: cleanup_files_(cleanup_files) {
+eblob_config_test_wrapper::eblob_config_test_wrapper(bool cleanup_files, int log_level)
+: cleanup_files_(cleanup_files)
+, log_level_(log_level) {
 	reset_dirs();
 	config.blob_flags = EBLOB_L2HASH | EBLOB_DISABLE_THREADS | EBLOB_AUTO_INDEXSORT;
 	config.sync = -2;
@@ -42,7 +43,7 @@ void eblob_config_test_wrapper::reset_dirs() {
 	data_dir_ = mkdtemp(&data_dir_template_.front());
 	data_path_ = data_dir_ + "/data";
 	log_path_ = data_dir_ + "/log.log";
-	logger_.reset(new ioremap::eblob::eblob_logger(log_path_.c_str(), EBLOB_LOG_DEBUG));
+	logger_.reset(new ioremap::eblob::eblob_logger(log_path_.c_str(), log_level_));
 	config.log = logger_->log();
 	config.file = const_cast<char*>(data_path_.c_str());
 	config.chunks_dir = const_cast<char*>(data_dir_.c_str());

--- a/tests/unit/eblob_wrapper.h
+++ b/tests/unit/eblob_wrapper.h
@@ -13,7 +13,7 @@
 
 class eblob_config_test_wrapper {
 public:
-	eblob_config_test_wrapper(bool cleanup_files = true);
+	eblob_config_test_wrapper(bool cleanup_files = true, int log_level = EBLOB_LOG_DEBUG);
 	~eblob_config_test_wrapper();
 
 	eblob_config_test_wrapper(const eblob_config_test_wrapper &) = delete;
@@ -35,6 +35,7 @@ public:
 
 private:
 	bool cleanup_files_;
+	int log_level_;
 	std::string data_dir_template_;
 	std::string data_dir_;
 	std::string data_path_;


### PR DESCRIPTION
before we were splitting chunks by index order but it is inefficient
because if random reads. now we read whole index, sort it by position
and split chunk in that order.