### PR TITLE
add pthread_rwlock for iteration

### DIFF
--- a/library/blob.c
+++ b/library/blob.c
@@ -3409,9 +3409,13 @@ struct eblob_backend *eblob_init(struct eblob_config *c)
 	if (err != 0)
 		goto err_out_periodic_lock_destroy;
 
-	err = eblob_mutex_init(&b->defrag_state_lock);
+	err = pthread_rwlock_init(&b->iteration_lock, NULL);
 	if (err != 0)
 		goto err_out_inspect_lock_destroy;
+
+	err = eblob_mutex_init(&b->defrag_state_lock);
+	if (err != 0)
+		goto err_out_iteration_lock_destroy;
 
 	err = eblob_json_stat_init(b);
 	if (err != 0)
@@ -3459,6 +3463,8 @@ err_out_json_stat_destroy:
 	eblob_json_stat_destroy(b);
 err_out_defrag_state_lock_destroy:
 	pthread_mutex_destroy(&b->defrag_state_lock);
+err_out_iteration_lock_destroy:
+	pthread_rwlock_destroy(&b->iteration_lock);
 err_out_inspect_lock_destroy:
 	pthread_mutex_destroy(&b->inspect_lock);
 err_out_periodic_lock_destroy:

--- a/library/blob.c
+++ b/library/blob.c
@@ -3477,10 +3477,10 @@ err_out_exit_event_destroy:
 	eblob_event_destroy(&b->exit_event);
 err_out_cleanup:
 	eblob_bases_cleanup(b);
-err_out_l2hash_destroy:
-	eblob_l2hash_destroy(&b->l2hash);
 err_out_hash_destroy:
 	eblob_hash_destroy(&b->hash);
+err_out_l2hash_destroy:
+	eblob_l2hash_destroy(&b->l2hash);
 err_out_lock_destroy:
 	pthread_mutex_destroy(&b->lock);
 err_out_lockf:

--- a/library/blob.h
+++ b/library/blob.h
@@ -427,6 +427,7 @@ struct eblob_backend {
 	pthread_mutex_t		sync_lock;
 	pthread_mutex_t		periodic_lock;
 	pthread_mutex_t		inspect_lock;
+	pthread_rwlock_t	iteration_lock;
 
 	pthread_t		defrag_tid;
 	pthread_t		sync_tid;

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -211,6 +211,7 @@ int eblob_defrag_in_dir(struct eblob_backend *b, char *chunks_dir)
 			EBLOB_WARNX(b->cfg.log, EBLOB_LOG_INFO, "defrag: empty blob - removing.");
 
 			pthread_mutex_lock(&b->lock);
+			pthread_rwlock_wrlock(&b->iteration_lock);
 			/* Remove it from list, but do not poisson next and prev */
 			__list_del(bctl->base_entry.prev, bctl->base_entry.next);
 
@@ -221,6 +222,7 @@ int eblob_defrag_in_dir(struct eblob_backend *b, char *chunks_dir)
 			eblob_base_wait_locked(bctl);
 			_eblob_base_ctl_cleanup(bctl);
 			pthread_mutex_unlock(&bctl->lock);
+			pthread_rwlock_unlock(&b->iteration_lock);
 			pthread_mutex_unlock(&b->lock);
 			continue;
 		}

--- a/tests/stress/stress.c
+++ b/tests/stress/stress.c
@@ -659,7 +659,14 @@ static void test_iteration(struct test_cfg *cfg, struct eblob_config *bcfg, stru
 	}
 
 	warnx("iterating %lld keys: started", ipriv.shadow_count);
-	error = eblob_iterate(cfg->b, &eictl);
+	while ((error = eblob_iterate(cfg->b, &eictl))) {
+		if (error != -EBUSY)
+			break;
+
+		warnx("bases list is busy right now, wait...");
+		sleep(1);
+	}
+
 	if (error)
 		errx(EX_SOFTWARE, "iterating keys: failed: %d", error);
 


### PR DESCRIPTION
We need syncronization for iteration because of defrag may remove some
bctls from bases list and we don't want that somebody else could try to
iterate over broken bctl. So defrag thread iterating exclusively and
other thread take a read lock for iterating.