### PR TITLE
fix: merge offset and size to one field as they have same meaning

### DIFF
--- a/library/blob.h
+++ b/library/blob.h
@@ -93,7 +93,7 @@ static const size_t EBLOB_L2HASH_ENTRY_SIZE = sizeof(struct eblob_l2hash_entry);
 struct eblob_file_ctl {
 	int			fd;
 	int			sorted;
-	uint64_t		offset, size;
+	uint64_t		size;
 };
 
 #define EBLOB_INDEX_DEFAULT_BLOCK_SIZE			40

--- a/library/datasort.c
+++ b/library/datasort.c
@@ -609,7 +609,7 @@ static int datasort_add_view_chunk(struct datasort_ctl *ds_ctl, struct eblob_bas
 	// This is also valid for single pass sorting, as we don't require sorting
 	chunk->need_sort = 0;
 	chunk->base_view = 1;
-	chunk->offset = bctl->data_ctl.offset;
+	chunk->offset = bctl->data_ctl.size;
 	chunk->index_size = index_ctl->size / sizeof(struct eblob_disk_control);
 	chunk->count = chunk->index_size;
 	chunk->index = calloc(chunk->count, sizeof(struct eblob_disk_control));
@@ -1313,8 +1313,6 @@ static int datasort_swap_memory(struct datasort_ctl *ds_ctl)
 	}
 	assert(sorted_bctl->data_ctl.size == ds_ctl->result->offset);
 	assert(sorted_bctl->index_ctl.size == index.size);
-
-	sorted_bctl->data_ctl.offset = sorted_bctl->data_ctl.size;
 
 	/* Populate sorted index blocks */
 	if ((err = eblob_index_blocks_fill(sorted_bctl)) != 0) {

--- a/library/defrag.c
+++ b/library/defrag.c
@@ -72,9 +72,9 @@ int eblob_want_defrag(struct eblob_base_ctl *bctl)
 	size = eblob_stat_get(bctl->stat, EBLOB_LST_BASE_SIZE);
 	pthread_mutex_unlock(&bctl->lock);
 
-	/* Sanity: Do not remove seem-to-be empty blob if offsets are non-zero */
+	/* Sanity: Do not remove seem-to-be empty blob if sizes are non-zero */
 	if (((removed == 0) && (total == 0)) &&
-	    ((bctl->data_ctl.offset != 0) || (bctl->index_ctl.size != 0)))
+	    ((bctl->data_ctl.size != 0) || (bctl->index_ctl.size != 0)))
 		return -EINVAL;
 
 	if (total < removed)

--- a/library/index.c
+++ b/library/index.c
@@ -831,7 +831,6 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 	}
 
 	bctl->index_ctl.fd = fd;
-	bctl->index_ctl.offset = 0;
 	bctl->index_ctl.size = index_size;
 
 	err = eblob_index_blocks_fill(bctl);
@@ -866,7 +865,7 @@ int eblob_generate_sorted_index(struct eblob_backend *b, struct eblob_base_ctl *
 
 	eblob_log(b->cfg.log, EBLOB_LOG_INFO, "defrag: indexsort: generated sorted: index: %d, "
 			"index-size: %llu, data-size: %" PRIu64 ", file: %s\n",
-			bctl->index, (unsigned long long)index_size, bctl->data_ctl.offset, dst_file);
+			bctl->index, (unsigned long long)index_size, bctl->data_ctl.size, dst_file);
 
 	free(sorted_index);
 	free(file);

--- a/library/mobjects.c
+++ b/library/mobjects.c
@@ -112,7 +112,7 @@ int _eblob_base_ctl_cleanup(struct eblob_base_ctl *ctl)
 
 	eblob_index_blocks_destroy(ctl);
 
-	ctl->data_ctl.size = ctl->data_ctl.offset = 0;
+	ctl->data_ctl.size = 0;
 	ctl->index_ctl.size = 0;
 
 	close(ctl->index_ctl.fd);
@@ -780,9 +780,9 @@ static int eblob_iterate_existing(struct eblob_backend *b, struct eblob_iterate_
 					eblob_base_remove(bctl);
 
 					eblob_log(ctl->log, EBLOB_LOG_INFO, "blob: removing: index: %d, data_fd: %d, index_fd: %d, "
-							"data_size: %llu, data_offset: %llu, have_sort: %d\n",
+							"data_size: %llu, have_sort: %d\n",
 							bctl->index, bctl->data_ctl.fd, bctl->index_ctl.fd,
-							(unsigned long long)bctl->data_ctl.size, (unsigned long long)bctl->data_ctl.offset,
+							(unsigned long long)bctl->data_ctl.size,
 							bctl->index_ctl.sorted);
 
 
@@ -793,9 +793,9 @@ static int eblob_iterate_existing(struct eblob_backend *b, struct eblob_iterate_
 			}
 
 			eblob_log(ctl->log, EBLOB_LOG_INFO, "blob: bctl: index: %d, data_fd: %d, index_fd: %d, "
-					"data_size: %llu, data_offset: %llu, have_sort: %d, err: %d\n",
+					"data_size: %llu, have_sort: %d, err: %d\n",
 					bctl->index, bctl->data_ctl.fd, bctl->index_ctl.fd,
-					(unsigned long long)bctl->data_ctl.size, (unsigned long long)bctl->data_ctl.offset,
+					(unsigned long long)bctl->data_ctl.size,
 					bctl->index_ctl.sorted, err);
 			if (err)
 				goto err_out_bases_cleanup;


### PR DESCRIPTION
Merge index and offset fields into one in `eblob_file_ctl`, as they now all have the meaning of `size`
This also prevents triggering asserts in the code due to incorrect view chunk offset, for example in datasort.c:800