### PR TITLE
add alive_count to datasort_chunk

### DIFF
--- a/library/datasort.h
+++ b/library/datasort.h
@@ -51,6 +51,8 @@ struct datasort_chunk {
 	uint64_t			offset;
 	/* Number of records in chunk */
 	uint64_t			count;
+	/* Number of alive records in chunk */
+	uint64_t			alive_count;
 	/* Count of merged entries for n-way merge */
 	uint64_t			merge_count;
 	/* Full path to chunk file */


### PR DESCRIPTION
after add of views over bases we began get removed records in
datasort_merge and it broke assert with total_items. now we account only
alive records there.